### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
       - 'release/**'
       - 'feature/**'
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tobrien/gitcarve/security/code-scanning/4](https://github.com/tobrien/gitcarve/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required. Based on the workflow's steps:
- `contents: read` is needed to check out the repository and read its contents.
- `contents: write` is required for the `codecov/codecov-action` step, which uploads coverage reports.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
