### PR TITLE
Potential fix for code scanning alert no. 6: Prototype-polluting function

### DIFF
--- a/src/util/general.ts
+++ b/src/util/general.ts
@@ -2,6 +2,9 @@
 export function deepMerge(target: any, source: any): any {
     for (const key in source) {
         if (Object.prototype.hasOwnProperty.call(source, key)) {
+            if (key === "__proto__" || key === "constructor") {
+                continue; // Skip prototype-polluting keys
+            }
             if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
                 if (!target[key]) {
                     target[key] = {};


### PR DESCRIPTION
Potential fix for [https://github.com/tobrien/gitcarve/security/code-scanning/6](https://github.com/tobrien/gitcarve/security/code-scanning/6)

To fix the issue, we need to explicitly block the special property names `__proto__` and `constructor` in the `deepMerge` function. This can be done by adding a condition to skip these properties during the merge process. This approach ensures that even if malicious input is provided, it cannot modify `Object.prototype`.

The changes will be made in the `deepMerge` function in `src/util/general.ts`:
1. Add a condition to skip the keys `__proto__` and `constructor` during the iteration over the `source` object.
2. Ensure that the rest of the functionality remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
